### PR TITLE
Close the CFP

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ layout: null
 						<h3>March 12-13, Menlo Park</h3>
                         <p>A chance for Red Teams to share knowledge and work together.</p>
 						<!--a class="tickets_btn" href="schedule.html">RTS {{ site.year }} Schedule</a><br/><br/-->
-						<a class="tickets_btn" href="https://cfp.redteamsummit.com/2020/cfp" target="_blank">CFP is Open</a>
+						<div class="tickets_btn">CFP is Closed</div>
 					</div>
 				</div>
             </div>

--- a/schedule.html
+++ b/schedule.html
@@ -25,8 +25,8 @@ layout: null
         <section class="event_schedule_area p_120">
         	<div class="container">
         		<div class="main_title">
-                    <h2><a class="tickets_btn" href="https://cfp.redteamsummit.com/2020/cfp" target="_blank">CFP is Open</a></h2>
-                    <p>Red Team Summit accepts submissions on November 20, 2019. The deadline for submissions is January 10, 2020.</p>
+                    <h2>Coming soon</h2>
+                    <p>Red Team Summit submissions deadline was January 10, 2020. Submitted talks are now under review. The schedule will be published soon.</p>
         		</div>
         	</div>
         </section>


### PR DESCRIPTION
The CFP closes at the end of Jan 10th (midnight Pacific time). This PR prepares those updates. 